### PR TITLE
update how collapse states are stored in localstorage

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -28,6 +28,6 @@
   "dependencies": {
     "ember": "~1.5.1",
     "bootstrap": "~3.2.0",
-    "Inspector-JSON": "SparkartGroupInc/Inspector-JSON#~0.1.0"
+    "Inspector-JSON": "SparkartGroupInc/Inspector-JSON#e6bec9fe4cc7551cd46f44bafed6891620a5e47d"
   }
 }

--- a/views/devpanel.js
+++ b/views/devpanel.js
@@ -20,6 +20,7 @@ function processMainIncomingMessage(msg) {
     } else {
       inspector = new InspectorJSON({
         element: 'pagecontext',
+        url: msg.url.path,
         json: msg
       });
     }


### PR DESCRIPTION
This pull request resolves #3 by pulling in an updated version of Inspector-JSON and storing the collapsed states under the JSON path rather than the devtools.html path, so paths are stored per inspected page.
